### PR TITLE
Fix broken urls from on wpf dir url

### DIFF
--- a/includes/admin/class-admin-bar.php
+++ b/includes/admin/class-admin-bar.php
@@ -45,7 +45,7 @@ class WPF_Admin_Bar {
 
 	public function admin_bar_style() {
 
-		wp_enqueue_style( 'wpf-admin-bar', WPF_DIR_URL . '/assets/css/wpf-admin-bar.css', array(), WP_FUSION_VERSION );
+		wp_enqueue_style( 'wpf-admin-bar', WPF_DIR_URL . 'assets/css/wpf-admin-bar.css', array(), WP_FUSION_VERSION );
 
 	}
 

--- a/includes/class-access-control.php
+++ b/includes/class-access-control.php
@@ -1010,7 +1010,7 @@ class WPF_Access_Control {
 
 			} else {
 
-				wp_enqueue_script( 'wpf-apply-tags', WPF_DIR_URL . '/assets/js/wpf-apply-tags.js', array( 'jquery' ), WP_FUSION_VERSION, true );
+				wp_enqueue_script( 'wpf-apply-tags', WPF_DIR_URL . 'assets/js/wpf-apply-tags.js', array( 'jquery' ), WP_FUSION_VERSION, true );
 
 				if( ! isset( $wpf_settings['apply_tags'] ) ) {
 					$wpf_settings['apply_tags'] = null;

--- a/includes/class-ajax.php
+++ b/includes/class-ajax.php
@@ -189,7 +189,7 @@ class WPF_AJAX {
 
 		if ( ! wp_script_is( 'wpf-apply-tags' ) && wp_fusion()->settings->get( 'link_click_tracking' ) == true ) {
 
-			wp_enqueue_script( 'wpf-apply-tags', WPF_DIR_URL . '/assets/js/wpf-apply-tags.js', array( 'jquery' ), WP_FUSION_VERSION, true );
+			wp_enqueue_script( 'wpf-apply-tags', WPF_DIR_URL . 'assets/js/wpf-apply-tags.js', array( 'jquery' ), WP_FUSION_VERSION, true );
 			wp_localize_script( 'wpf-apply-tags', 'wpf_ajax', array( 'ajaxurl' => admin_url( 'admin-ajax.php' ) ) );
 
 		}


### PR DESCRIPTION
I was getting broken links for this reference on my server. I belive the intention is to link to wp-fusion-lite/assets... and not wp-fusion-lite//assets...