### PR TITLE
Fix Mautic JS tracking code url

### DIFF
--- a/includes/crms/mautic/class-mautic.php
+++ b/includes/crms/mautic/class-mautic.php
@@ -80,7 +80,7 @@ class WPF_Mautic {
 		echo '(function(w,d,t,u,n,a,m){w["MauticTrackingObject"]=n;';
 		echo 'w[n]=w[n]||function(){(w[n].q=w[n].q||[]).push(arguments)},a=d.createElement(t),';
 		echo 'm=d.getElementsByTagName(t)[0];a.async=1;a.src=u;m.parentNode.insertBefore(a,m)';
-		echo '})(window,document,"script","' . trtim(wp_fusion()->settings->get( 'mautic_url' ),'/') . '/mtc.js","mt");';
+		echo '})(window,document,"script","' . rtrim(wp_fusion()->settings->get( 'mautic_url' ),'/') . '/mtc.js","mt");';
 
 		    echo 'mt("send", "pageview");';
 

--- a/includes/crms/mautic/class-mautic.php
+++ b/includes/crms/mautic/class-mautic.php
@@ -80,7 +80,7 @@ class WPF_Mautic {
 		echo '(function(w,d,t,u,n,a,m){w["MauticTrackingObject"]=n;';
 		echo 'w[n]=w[n]||function(){(w[n].q=w[n].q||[]).push(arguments)},a=d.createElement(t),';
 		echo 'm=d.getElementsByTagName(t)[0];a.async=1;a.src=u;m.parentNode.insertBefore(a,m)';
-		echo '})(window,document,"script","' . wp_fusion()->settings->get( 'mautic_url' ) . '","mt");';
+		echo '})(window,document,"script","' . trtim(wp_fusion()->settings->get( 'mautic_url' ),'/') . '/mtc.js","mt");';
 
 		    echo 'mt("send", "pageview");';
 


### PR DESCRIPTION
In the WP Fusion plugin you have to input the mautic url in the **Setup** page.
This url is probably used to do the php api calls, so it is correct to input the raw url there.

However WP Fusion inserts the same url to the WP page for the Mautic tracking JS api.

```
<script>(function(w,d,t,u,n,a,m){w["MauticTrackingObject"]=n;w[n]=w[n]||function(){(w[n].q=w[n].q||[]).push(arguments)},a=d.createElement(t),m=d.getElementsByTagName(t)[0];a.async=1;a.src=u;m.parentNode.insertBefore(a,m)})(window,document,"script","{MauticUrl}","mt");mt("send", "pageview");</script>
```
That is not correct.

According to [Mautic documentation ](https://www.mautic.org/blog/developer/tracking-visitor-data-by-smart-url/)
It should look like this:

```
(function(w,d,t,u,n,a,m){w['MauticTrackingObject']=n;
        w[n]=w[n]||function(){(w[n].q=w[n].q||[]).push(arguments)},a=d.createElement(t),
        m=d.getElementsByTagName(t)[0];a.async=1;a.src=u;m.parentNode.insertBefore(a,m)
    })(window,document,'script','https://domain.com/mtc.js','mt');
```

(The difference is: **mtc.js**)