### PR TITLE
extend get_contact_id with mtc_id stored in cookie

### DIFF
--- a/includes/crms/mautic/class-mautic.php
+++ b/includes/crms/mautic/class-mautic.php
@@ -452,13 +452,15 @@ class WPF_Mautic {
 
 		$body_json    = json_decode( $response['body'], true );
 
-		if ( empty( $body_json['contacts'] ) ) {
+		if ( !empty( $body_json['contacts'] ) ) {
+			$contact = array_shift( $body_json['contacts'] );
+
+			return $contact['id'];		
+		}elseif(!empty($_COOKIE['mtc_id'])){
+			return $_COOKIE['mtc_id'];			
+		}else{
 			return false;
-		}
-
-		$contact = array_shift( $body_json['contacts'] );
-
-		return $contact['id'];
+		}				
 	}
 
 


### PR DESCRIPTION
Problem:
When a new contact is created, and contact_id is not present in WP Fusion for the user, WP Fusion only checks whether the corresponding email address is present in mautic, but doesn't use the contact id stored in `mtc_id` cookie.

Solution:
 If there was no contact found in Mautic with the corresponding email address, use `mtc_id` if it is set.

tl;dr
When the user arrives to the WP page IF the mautic tracking is enabled Mautic creates a new anonym contact. If then the user registers, WP Fusion creates a new user and syncronizes it towards Mautic.

1) It first checks whether the user already got a contact_id from the crm. If there is a contact_id stored in the WP database to the user, it tries to use it for update
2) If a contact_id for the user is not present in the WP database, it tries to get a contact_id from Mautic. It checks if there is a lead in the Mautic database with the corresponding email address. If a contact is found, WP fusion tries to use the contact_id for update.
3) If there was no contact found in Mautic with the corresponding email address, WP fusion currently continues to add_contact

But instead if should check if the mautic JS api already created a contact for which the id is stored in `mtc_id` cookie.
