### PR TITLE
Validate contact_id stored in WP Fusion

### DIFF
--- a/includes/class-user.php
+++ b/includes/class-user.php
@@ -357,6 +357,12 @@ class WPF_User {
 
 		$contact_id = get_user_meta( $user_id, wp_fusion()->crm->slug . '_contact_id', true );
 
+		if (!empty($contact_id)){
+			if (method_exists(wp_fusion()->crm, 'validate_contact_id')){
+				$contact_id = wp_fusion()->crm->validate_contact_id($contact_id);
+			}
+		}
+		
 		// If contact ID is already set
 		if ( ( ! empty( $contact_id ) || $contact_id == false ) && $force_update == false ) {
 			return $contact_id;

--- a/includes/crms/mautic/class-mautic.php
+++ b/includes/crms/mautic/class-mautic.php
@@ -460,7 +460,33 @@ class WPF_Mautic {
 
 		return $contact['id'];
 	}
+	
+	/**
+	 * Validate a contact_id
+	 *
+	 * @access public
+	 * @return int contact_id or false
+	 */
 
+	public function validate_contact_id( $contact_id ) {
+
+		if (empty($contact_id)) {
+			return false;
+		}
+
+		if ( ! $this->params ) {
+			$this->get_params();
+		}
+
+		$url      = $this->url . 'api/contacts/' . $contact_id;;
+		$response = wp_remote_get( $url, $this->params );
+
+		if( is_wp_error( $response ) ) {
+			return false;
+		}
+
+		return $contact_id;
+	}
 
 	/**
 	 * Gets all tags currently applied to the user, also update the list of available tags


### PR DESCRIPTION
Problem:
WP Fusion doesn't follow mautic contact merges

Solution:
Validate contact_id stored in WP Fusion and if the contact_id is invalid, consider it as if no contact_id value was stored before and continue on requesting contact_id from the CRM (search by email)


tl;dr
Mautic sometimes performs contact merges. This may happen for example if a user visits the page from a different device and after a few tracked pageviews (Mautic tracking must be active) the user logs in the user gets identified by email and mautic merges the current anonym tracked contact with the contact that was already stored with email.
If the former contact came out from the merge as winner (mautic keeps the winner's contact_id) it would cause inconsistency with the contact_id that is stored in WP Fusion.

It seems to me that WP Fusion doesn't handle if a contact_id stored in WP Fusion to a user does not exists anymore. This case simply causes update errors.

To solve this `validate_contact_id` is added to the common `get_contact_id` function to check whether the contact_id stored in WP Fusion is still exists in Mautic.
If the contact_id happens to be invalid the `validate_contact_id` return false which results in the same situation as if there was never a stored contact_id. The `get_contact_id` continues on requesting contact_id from the crm by email.


