### PR TITLE
update mtc_id if new user signs in

### DIFF
--- a/includes/crms/mautic/class-mautic.php
+++ b/includes/crms/mautic/class-mautic.php
@@ -112,7 +112,7 @@ class WPF_Mautic {
 
 		$contact_id = wp_fusion()->user->get_contact_id();
 
-		if( ! empty( $contact_id ) && ! isset( $_COOKIE['mtc_id'] ) ) {
+		if( ! empty( $contact_id ) && ( ! isset( $_COOKIE['mtc_id'] ) || $_COOKIE['mtc_id'] != $contact_id ) ){
 
 			setcookie( 'mtc_id', $contact_id, time() + DAY_IN_SECONDS * 730, COOKIEPATH, COOKIE_DOMAIN );
 


### PR DESCRIPTION
I believe `mtc_id` cookie  should be updated if another user signs in to the WP site.
(This change is done by the Mautic JS api too, but only if the tracking is enabled.)