### PR TITLE
validate mtc_id before use

### DIFF
--- a/includes/crms/mautic/class-mautic.php
+++ b/includes/crms/mautic/class-mautic.php
@@ -466,7 +466,30 @@ class WPF_Mautic {
 
 			return $contact['id'];		
 		}elseif(!empty($_COOKIE['mtc_id'])){
-			return $_COOKIE['mtc_id'];			
+			$url      = $this->url . 'api/contacts/' . $contact_id;;
+			$response = wp_remote_get( $url, $this->params );
+			if( is_wp_error( $response ) ) {
+				return $response;
+			}
+
+			$body_json    = json_decode( $response['body'], true );
+			if (!empty($body_json['contact']['id'])){
+				if (!empty($body_json['contact']['fields']['all']['email'])){
+					if ($body_json['contact']['fields']['all']['email'] == $email_address){
+						//contact with mtc_id have the same email as the one submitted, proceed with mtc_id
+						return $_COOKIE['mtc_id'];
+					}else{
+						//contact with mtc_id have different email than the one submitted, proceed with creating a new contact
+						return false;		
+					}
+				}else{
+					//contact with mtc_id doesn't have email address, proceed with mtc_id
+					return $_COOKIE['mtc_id'];	
+				}
+			}else{
+				//contact with mtc_id doesn't exist anymore, proceed with creating a new contact
+				return false;
+			}			
 		}else{
 			return false;
 		}				


### PR DESCRIPTION
In a previous PR we introduced that if the user has no contact_id stored in WP and a contact_id cannot be retrieved from Mautic by email, then WP Fusion should use the mtc_id stored in cookies as a contact_id instead of creating a new user in Mautic.

While this approach solved a problem (to use the contact_id during new user registration that was previously set as a cookie by Mautic JS Api) it also introduced a new one:

If a user registers to the WP site, its contact_id gets set as a cookie. 
If the user logs out and a new user tries to register **on the same device**, then the contact_id of the previous user (mtc_id) gets used to identify the contact confusing the contact data in mautic.

Instead of 
1) new user registers
2) WP Fusion checks whether the user has contact_id stored in WP 
3) WP fusion tries to retrieve contact_id from Mautic by email
4) WP Fusion checks if mtc_id is present and uses it as contact_id

It should do the following steps:
1) new user registers
2) WP Fusion checks whether the user has contact_id stored in WP
3) WP fusion tries to retrieve contact_id from Mautic by email
4) WP Fusion checks if mtc_id is present
5) WP fusion checks if a contact is still exists by the contact_id stored as mtc_id
6) WP Fusion checks if the contact identified by mtc_id as email
7) If the email of the contact identified by mtc_id differs from the email of the new user, it proceeds without using mtc_id