### PR TITLE
Return $status to set-screen-option filter if $option is not 'wpf_status_log_items_per_page'

### DIFF
--- a/includes/admin/logging/class-log-handler.php
+++ b/includes/admin/logging/class-log-handler.php
@@ -156,6 +156,7 @@ class WPF_Log_Handler {
 	 	if ( 'wpf_status_log_items_per_page' == $option ) {
 	 		return $value;
 	 	}
+	 	return $status;
 
 	 }
 


### PR DESCRIPTION
Hi there,

I'm one of the support team from @eventespresso and we recently ran into an issue with WP Fusion preventing our per_page option from updating.

After a little digging, I found that the [callback function](https://github.com/verygoodplugins/wp-fusion-lite/blob/master/includes/admin/logging/class-log-handler.php#L154-L160) on the `set-screen-option` filter doesn't return the filtered `$status` so it nulls any other options that aren't whitelisted from within [set_screen_options()](https://developer.wordpress.org/reference/functions/set_screen_options/).

This caused a 302 redirect on our list tables which then meant no $_POST values and no per_page update.
 