### PR TITLE
PulseTechnologyCRM: Adding a slash at the end of the URL to avoid problems using the API

### DIFF
--- a/includes/crms/pulsetech/class-pulsetech.php
+++ b/includes/crms/pulsetech/class-pulsetech.php
@@ -170,7 +170,9 @@ class WPF_PulseTechnologyCRM {
 			$token = null;
 		}
 
-		$this->url           = $api_url;
+        $api_url = rtrim($api_url, '/') . '/';
+
+        $this->url           = $api_url;
 		$this->client_secret = $client_secret;
 		$this->client_id     = $client_id;
 		$this->token         = $token;


### PR DESCRIPTION
Small improvement on the PulseTechnologyCRM, I'm adding a slash at the end of the URL to avoid problems using the API so it will work with:
http://mywebsite.com 
http://mywebsite.com/ 


