### PR TITLE
Growmatik update 2

### DIFF
--- a/includes/crms/growmatik/admin/growmatik-fields.php
+++ b/includes/crms/growmatik/admin/growmatik-fields.php
@@ -2,11 +2,6 @@
 
 $growmatik_fields = array();
 
-$growmatik_fields['user_login'] = array(
-	'crm_label' => 'Username',
-	'crm_field' => 'userName',
-);
-
 $growmatik_fields['user_email'] = array(
 	'crm_label' => 'Email',
 	'crm_field' => 'email',
@@ -45,11 +40,6 @@ $growmatik_fields['billing_state'] = array(
 $growmatik_fields['billing_city'] = array(
 	'crm_label' => 'City',
 	'crm_field' => 'city',
-);
-
-$growmatik_fields['user_registered'] = array(
-	'crm_label' => 'Registration Date',
-	'crm_field' => 'registrationAt',
 );
 
 $growmatik_fields[''] = array(


### PR DESCRIPTION
Hi and good day to WP Fusion!
I'm reaching out from Artbees company ► Growmatik team.
There were some changes needed to be done in your plugin to improve the integration with our CRM.

1.  Basic fields [Username] and [Registration Date] were to be removed because based on our new BE changes, they shouldn't be changeable from API requests, hence not meaningful to give the mapping option for them.
2.  Because of having a separate endpoint for receiving custom attributes on our side, these fields were not being updated right after user creation and a manual "Push Meta" was required to achieve the result. To fix it, I added a subsequent request right after creation of the new user, to custom attrs endpoint.

Thanks for your collaboration in advance
Regards
Ali Memarzadeh - Growmatik