### PR TITLE
fix(hubspot): add missing v3 list id mapper

### DIFF
--- a/includes/crms/hubspot/admin/class-admin.php
+++ b/includes/crms/hubspot/admin/class-admin.php
@@ -1125,63 +1125,10 @@ class WPF_HubSpot_Admin {
 		// The API expects string IDs.
 		$legacy_ids = array_map( 'strval', array_keys( $orphaned_ids ) );
 
-		if ( ! $this->crm->params ) {
-			$this->crm->get_params();
-		}
+		$id_map = $this->crm->get_v3_list_ids( $legacy_ids );
 
-		if ( empty( $this->crm->params ) ) {
-			return new WP_Error( 'auth', __( 'Unable to connect to HubSpot.', 'wp-fusion-lite' ) );
-		}
-
-		$v3_lists = $this->crm->sync_tags_v3();
-
-		if ( is_wp_error( $v3_lists ) ) {
-			return $v3_lists;
-		}
-
-		$v3_list_ids = array_map( 'strval', array_keys( $v3_lists ) );
-		$id_map      = array();
-
-		foreach ( array_chunk( $legacy_ids, 10000 ) as $chunk ) {
-
-			$params           = $this->crm->params;
-			$params['body']   = wp_json_encode( $chunk );
-			$params['method'] = 'POST';
-
-			$response = wp_remote_request( 'https://api.hubapi.com/crm/v3/lists/idmapping', $params );
-
-			if ( is_wp_error( $response ) ) {
-				wpf_log( 'error', 0, 'HubSpot v1→v3 ID mapping API error: ' . $response->get_error_message() );
-				return $response;
-			}
-
-			$body = json_decode( wp_remote_retrieve_body( $response ), true );
-
-			if ( empty( $body['legacyListIdsToIdsMapping'] ) || ! is_array( $body['legacyListIdsToIdsMapping'] ) ) {
-				continue;
-			}
-
-			foreach ( $body['legacyListIdsToIdsMapping'] as $mapping ) {
-				$legacy_id = (string) $mapping['legacyListId'];
-				$new_id    = (string) $mapping['listId'];
-
-				// Skip self-mappings (no change needed).
-				if ( $legacy_id === $new_id ) {
-					continue;
-				}
-
-				// Skip if the legacy ID already exists as a valid v3 list.
-				// This prevents corrupting settings that reference the
-				// v3 list when a v1 list shares the same numeric ID.
-				if ( in_array( $legacy_id, $v3_list_ids, true ) ) {
-					continue;
-				}
-
-				// Only map to IDs that exist in live v3 list results.
-				if ( in_array( $new_id, $v3_list_ids, true ) ) {
-					$id_map[ $legacy_id ] = $new_id;
-				}
-			}
+		if ( is_wp_error( $id_map ) ) {
+			return $id_map;
 		}
 
 		if ( empty( $id_map ) ) {

--- a/includes/crms/hubspot/class-hubspot.php
+++ b/includes/crms/hubspot/class-hubspot.php
@@ -1130,6 +1130,78 @@ class WPF_HubSpot {
 
 
 	/**
+	 * Maps legacy HubSpot v1 list IDs to current v3 list IDs.
+	 *
+	 * @since 3.47.8
+	 *
+	 * @param array<int|string> $legacy_ids Legacy HubSpot list IDs.
+	 * @return array<string, string>|WP_Error
+	 */
+	public function get_v3_list_ids( $legacy_ids ) {
+
+		if ( empty( $legacy_ids ) || ! is_array( $legacy_ids ) ) {
+			return array();
+		}
+
+		if ( ! $this->params ) {
+			$this->get_params();
+		}
+
+		if ( empty( $this->params ) ) {
+			return new WP_Error( 'auth', __( 'Unable to connect to HubSpot.', 'wp-fusion-lite' ) );
+		}
+
+		$v3_lists = $this->sync_tags_v3();
+
+		if ( is_wp_error( $v3_lists ) ) {
+			return $v3_lists;
+		}
+
+		$v3_list_ids = array_map( 'strval', array_keys( $v3_lists ) );
+		$id_map      = array();
+
+		foreach ( array_chunk( array_map( 'strval', $legacy_ids ), 10000 ) as $chunk ) {
+
+			$params           = $this->params;
+			$params['body']   = wp_json_encode( $chunk );
+			$params['method'] = 'POST';
+
+			$response = wp_remote_request( 'https://api.hubapi.com/crm/v3/lists/idmapping', $params );
+
+			if ( is_wp_error( $response ) ) {
+				wpf_log( 'error', 0, 'HubSpot v1→v3 ID mapping API error: ' . $response->get_error_message() );
+				return $response;
+			}
+
+			$body = json_decode( wp_remote_retrieve_body( $response ), true );
+
+			if ( empty( $body['legacyListIdsToIdsMapping'] ) || ! is_array( $body['legacyListIdsToIdsMapping'] ) ) {
+				continue;
+			}
+
+			foreach ( $body['legacyListIdsToIdsMapping'] as $mapping ) {
+				$legacy_id = isset( $mapping['legacyListId'] ) ? (string) $mapping['legacyListId'] : '';
+				$new_id    = isset( $mapping['listId'] ) ? (string) $mapping['listId'] : '';
+
+				if ( empty( $legacy_id ) || empty( $new_id ) || $legacy_id === $new_id ) {
+					continue;
+				}
+
+				if ( in_array( $legacy_id, $v3_list_ids, true ) ) {
+					continue;
+				}
+
+				if ( in_array( $new_id, $v3_list_ids, true ) ) {
+					$id_map[ $legacy_id ] = $new_id;
+				}
+			}
+		}
+
+		return $id_map;
+	}
+
+
+	/**
 	 * Loads all custom fields from CRM and merges with local list
 	 *
 	 * @access public


### PR DESCRIPTION
Fixes a HubSpot admin fatal caused by calling a CRM method that did not exist in Lite.

## What changed:
Added WPF_HubSpot::get_v3_list_ids() to centralize the v1 to v3 list ID mapping logic.
Updated the HubSpot admin migration flow to reuse that CRM method instead of duplicating the mapping implementation.
Preserved the existing safeguards around self-mappings and invalid/stale list IDs.

## Why:
After the migration safety-net auto-build started calling get_v3_list_ids(), Lite could fatal on admin_init because the method existed in the call path but not on the HubSpot CRM class.

## Validation:
- `php -l includes/crms/hubspot/class-hubspot.php`
- `php -l includes/crms/hubspot/admin/class-admin.php`